### PR TITLE
add WithClusterAutoScaler on cluster.spec

### DIFF
--- a/cluster/types.go
+++ b/cluster/types.go
@@ -78,6 +78,12 @@ type ClusterSpec struct {
 	// any resource that does not tolerate the Taint.
 	// +optional
 	Taints []corev1.Taint
+
+	// WithClusterAutoScaler indicates that the cluster has cluster-autoscaler component.
+	// it means the cluster always has enough resources.
+	// Defaults to false.
+	// +optional
+	WithClusterAutoScaler bool
 }
 
 const (


### PR DESCRIPTION
there are two k8s cluster in our company: k8s in idc, tke/k8s in cloud company(like tencent cloud). we use cluster autoscaler in tke, if there are pending pod, tke will scale up a new node into cluster. so we can see the tke cluster is elastic.

in order to delivery the pods to elastic cluster even though the cluster has no resources, we should mark the cluster is elastic  firstly, so we may need add a field on cluster.spec

related issue: https://github.com/karmada-io/karmada/issues/2583